### PR TITLE
csf-parser: user https authentication

### DIFF
--- a/recipes-utils/csf-parser/csf-parser_3.4.1.bb
+++ b/recipes-utils/csf-parser/csf-parser_3.4.1.bb
@@ -1,4 +1,6 @@
 DESCRIPTION = "NXP CSF parser tool"
+# Manually download the cst tarball from the link below into the S directory
+# if the SRC_URI repository is not accessible.
 HOMEPAGE = "https://www.nxp.com/webapp/Download?colCode=IMX_CST_TOOL"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = " \
@@ -6,7 +8,7 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.hidapi;md5=e0ea014f523f64f0adb13409055ee59e \
     file://LICENSE.openssl;md5=3441526b1df5cc01d812c7dfc218cea6 \
 "
-SRC_URI = "git://git@github.com/balena-os/cst.git;protocol=ssh;branch=master"
+SRC_URI = "git://github.com/balena-os/cst.git;protocol=https;branch=master"
 SRCREV = "b511d26d7f1f9323bc21485523b259ad9d437442"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This makes it easier to allow build nodes to access the private cst repository.

Change-type: patch