### PR TITLE
Modify secure boot setup to check hab events before closing

### DIFF
--- a/recipes-bsp/u-boot/hab/env_resin.h
+++ b/recipes-bsp/u-boot/hab/env_resin.h
@@ -117,7 +117,7 @@
                "run resin_scan_devs; " \
                "if test -n \"${resin_flasher_dev_index}\"; then " \
                        "echo Found resin flasher on ${resin_dev_type} ${resin_flasher_dev_index}; "\
-                       "setenv bootparam_flasher flasher migrate; "\
+                       "hab_status; setenv bootparam_flasher flasher migrate hab_status=${hab_status}; "\
                        "setenv resin_dev_index ${resin_flasher_dev_index}; "\
                "else; "\
                        "if test -n \"${resin_image_dev_index}\"; then " \

--- a/recipes-bsp/u-boot/hab/hab-set-hab-status-in-environment.patch
+++ b/recipes-bsp/u-boot/hab/hab-set-hab-status-in-environment.patch
@@ -1,0 +1,30 @@
+From: Alex Gonzalez <alexg@balena.io>
+Date: Mon, 3 Feb 2025 12:13:58 +0100
+Subject: [PATCH] hab: set hab status in environment
+
+This allows to pass the status to user space and helps when provisioning.
+
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+---
+ arch/arm/mach-imx/hab.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm/mach-imx/hab.c b/arch/arm/mach-imx/hab.c
+index 36f1810826c2..3638c001126e 100644
+--- a/arch/arm/mach-imx/hab.c
++++ b/arch/arm/mach-imx/hab.c
+@@ -474,12 +474,14 @@ static int get_hab_status(void)
+ 			bytes = sizeof(event_data);
+ 			index++;
+ 		}
++		env_set("hab_status", "1");
+ 	}
+ 	/* Display message if no HAB events are found */
+ 	else {
+ 		printf("\nHAB Configuration: 0x%02x, HAB State: 0x%02x\n",
+ 		       config, state);
+ 		puts("No HAB Events Found!\n\n");
++		env_set("hab_status", "0");
+ 	}
+ 	return 0;
+ }

--- a/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
@@ -47,6 +47,7 @@ SRC_URI:append:mx8m-generic-bsp = " \
     file://mach-imx-hab-allow-to-specify-custom-IVT-offset-from.patch \
     file://image-fdt-introduce-HAB-authentication-for-device-tr.patch \
     file://cmd-boot-panic-if-image-authentication-fails.patch \
+    file://hab-set-hab-status-in-environment.patch \
 "
 
 do_configure:prepend:mx8m-generic-bsp () {

--- a/recipes-support/resin-init/files/balena-init-flasher-imx-secureboot
+++ b/recipes-support/resin-init/files/balena-init-flasher-imx-secureboot
@@ -20,6 +20,13 @@ if ! command -v split_bootpartition > /dev/null; then . /usr/libexec/os-helpers-
 
 BALENA_NONENC_BOOT_LABEL=@@BALENA_NONENC_BOOT_LABEL@@
 
+is_srk_programmed() {
+    if imx-otp-tool show | grep "SRK hashes:" | grep -q "non-null, locked"; then
+        return 0
+    fi
+    return 1
+}
+
 secureboot_setup() {
     if [ "$(jq .installer.secureboot "${CONFIG_PATH}")" = "true" ]; then
         if @@BALENA_SKIP_SECUREBOOT_SETUP@@; then
@@ -29,12 +36,37 @@ secureboot_setup() {
         if ! command -v imx-otp-tool > /dev/null; then
             fail "IMX OTP tool is required"
         fi
-        info "Programming OTP with ${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/efuses.bin"
-        if imx-otp-tool -q --fuse-file "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/efuses.bin" secure; then
-            imx-otp-tool show
+        if is_secured; then
+            info "Device is already closed"
             return 0
+        fi
+        # If HAB complains, it could be u-boot needs to be programmed with the signed version
+        if ! cat /proc/cmdline | grep -q "hab_status=0"; then
+            # Note this happens on the eMMC boot partition
+            /usr/bin/resin-init-flasher-board
+            reboot -f
+        fi
+
+        if ! is_srk_programmed; then
+            # Program OTP SRK and reboot
+            info "Programming OTP with ${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/efuses.bin"
+            if imx-otp-tool -q --fuse-file "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/efuses.bin" srks; then
+                imx-otp-tool show
+                reboot -f
+            fi
         else
-            fail "Failed to program OTP fuses"
+            # Check hab_status
+            if cat /proc/cmdline | grep -q "hab_status=0"; then
+                info "No HAB events reported - closing device."
+                if imx-otp-tool -q --fuse-file "${EXTERNAL_DEVICE_BOOT_PART_MOUNTPOINT}/efuses.bin" secure; then
+                    imx-otp-tool show
+                    reboot -f
+                else
+                    fail "Failed to program OTP fuses"
+                fi
+            else
+                fail "HAB events detected - refusing to close device"
+            fi
         fi
     elif is_secured; then
         fail "Device is locked - please opt-in secure boot mode in the installer configuration"

--- a/recipes-utils/imx-misc-tools/files/imx-otp-tool-separate-SRK-programming-into-different.patch
+++ b/recipes-utils/imx-misc-tools/files/imx-otp-tool-separate-SRK-programming-into-different.patch
@@ -1,0 +1,88 @@
+From: Alex Gonzalez <alexg@balena.io>
+Date: Mon, 3 Feb 2025 13:49:10 +0100
+Subject: [PATCH] imx-otp-tool: separate SRK programming into different command
+
+This allows to program the SRK e-fuses and check hab status before
+closing the device.
+
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+---
+ imx-otp-tool.c | 31 ++++++++++++++++++++++++++-----
+ 1 file changed, 26 insertions(+), 5 deletions(-)
+
+diff --git a/imx-otp-tool.c b/imx-otp-tool.c
+index dcfea1f1ceab..e6cf57d7a668 100644
+--- a/imx-otp-tool.c
++++ b/imx-otp-tool.c
+@@ -35,6 +35,7 @@ static int8_t slot = -1;
+ typedef int (*option_routine_t)(otpctx_t ctx, int argc, char * const argv[]);
+ static int do_check_secure(otpctx_t ctx, int argc, char * const argv[]);
+ static int do_secure(otpctx_t ctx, int argc, char * const argv[]);
++static int do_srks(otpctx_t ctx, int argc, char * const argv[]);
+ static int do_show(otpctx_t ctx, int argc, char * const argv[]);
+ static int do_revoke(otpctx_t ctx, int argc, char * const argv[]);
+ static char * bootcfg_get_jtag_smode(uint32_t * bootcfg, char * msg, size_t msglen);
+@@ -47,7 +48,8 @@ static struct {
+ 	const char *help;
+ } commands[] = {
+         { "is-secured", do_check_secure, "check fuses are set for secure boot" },
+-        { "secure",     do_secure,       "program fuses for secure boot" },
++        { "secure",     do_secure,       "program SRK fuses for secure boot and close device" },
++        { "srks",       do_srks,         "program SRK fuses for secure boot" },
+         { "show",       do_show,         "show fuses" },
+         { "revoke",     do_revoke,       "revoke key slot" },
+ };
+@@ -295,16 +297,14 @@ static int twobit_bootcfg_update(otpctx_t ctx, uint32_t * bootcfg, uint32_t offs
+ }
+ 
+ /*
+- * do_secure
++ * do_srks
+  */
+ static int
+-do_secure (otpctx_t ctx, int argc, char * const argv[])
++do_srks (otpctx_t ctx, int argc, char * const argv[])
+ {
+ 	uint32_t srk_hash[SRK_FUSE_COUNT];
+-	uint32_t bootcfg[OTP_BOOTCFG_WORD_COUNT];
+ 	uint32_t locks;
+ 	otp_lockstate_t lstate;
+-	bool val;
+ 	unsigned int i;
+ 
+ 	if (!have_srk_hash) {
+@@ -335,6 +335,7 @@ do_secure (otpctx_t ctx, int argc, char * const argv[])
+ 		if (!opt_quiet)
+ 			printf("Programmed SRK fuses.\n");
+ 	}
++
+ 	if (otp_locks_read(ctx, &locks) < 0) {
+ 		perror("otp_locks_read");
+ 		return 1;
+@@ -363,6 +364,26 @@ do_secure (otpctx_t ctx, int argc, char * const argv[])
+ 		fprintf(stderr, "ERR: unknown SRK lockstate: %u\n", lstate);
+ 		return 1;
+ 	}
++	return 0;
++
++} /* do_srks */
++
++/*
++ * do_secure
++ */
++static int
++do_secure (otpctx_t ctx, int argc, char * const argv[])
++{
++	uint32_t srk_hash[SRK_FUSE_COUNT];
++	uint32_t bootcfg[OTP_BOOTCFG_WORD_COUNT];
++	uint32_t locks;
++	otp_lockstate_t lstate;
++	bool val;
++	unsigned int i;
++
++	if (do_srks(ctx, argc, argv) != 0) {
++		return 1;
++	}
+ 
+ 	if (otp_bootcfg_read(ctx, bootcfg, OTP_BOOTCFG_WORD_COUNT) < 0) {
+ 		perror("otp_bootcfg_read");

--- a/recipes-utils/imx-misc-tools/imx-misc-tools_git.bb
+++ b/recipes-utils/imx-misc-tools/imx-misc-tools_git.bb
@@ -10,6 +10,7 @@ SRC_URI = " \
     file://Add-i.MX8MP-support.patch \
     file://imx-otp-tool-add-JTAG-disabling-to-secure-mode.patch \
     file://imx-otp-tool-add-revocation-command.patch \
+    file://imx-otp-tool-separate-SRK-programming-into-different.patch \
 "
 SRCREV = "401a93f3422012bbfada6fcc2a920ded2f73dc04"
 S = "${WORKDIR}/git"

--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,1 @@
+type: generic


### PR DESCRIPTION
This is a more defensive implementation of the secure boot provisioning - checking at every step that the device is in the correct state before applying potentially destructive configuration.

* Only programs SRKs if the bootloader reports no HAB events
* Only locks the device if the SRK have been programmed and the bootloader reports no HAB events
* Reboots after both SRK and locking, the latter so that the master key is updated before the encryption of partitions