### PR TITLE
hostapp-update-hooks: replace use of file by magic header

### DIFF
--- a/recipes-support/hostapp-update-hooks/hostapp-update-hooks/0-signed-update
+++ b/recipes-support/hostapp-update-hooks/hostapp-update-hooks/0-signed-update
@@ -57,17 +57,16 @@ extract_slot_index() {
         fail "CSF parser not found"
     fi
 
-    _filetype=$(file --mime-type -b "${_boot_artifact}")
-    if [ "${_filetype}" = "application/gzip" ]; then
+    GZIP_MAGIC="1f8b"
+    _filetype=$(xxd -p -l 2 "${_boot_artifact}")
+    if [ "${_filetype}" = "${GZIP_MAGIC}" ]; then
         _n_artifact="${_tmpdir}/$(basename ${_boot_artifact})"
         gunzip -c "${_boot_artifact}" > "${_n_artifact}"
         _boot_artifact="${_n_artifact}"
     fi
-    # Currently the u-boot fit image identified as data fails parsing
-    # with an unrecognized tag.
-    # For octet-stream type we skip failing on parsing error and rely on the
-    # existence of the parsed output to confirm signing.
-    if ! "$(command -v csf_parser)" -s "${_boot_artifact}" > /dev/null && [ "${_filetype}" != "application/octet-stream" ]; then
+    # Currently the u-boot fit image fails parsing with an unrecognized tag so
+    # we rely on the existence of the parsed output to confirm signing.
+    if ! "$(command -v csf_parser)" -s "${_boot_artifact}" > /dev/null && [ "${_boot_artifact}" != "${_boot_artifact#imx-boot-*flash_evk}" ]; then
         rm -rf "${_tmpdir}"
         fail "No signature found in ${_boot_artifact}"
     else

--- a/recipes-utils/csf-parser/csf-parser_3.4.1.bb
+++ b/recipes-utils/csf-parser/csf-parser_3.4.1.bb
@@ -13,7 +13,7 @@ S = "${WORKDIR}/git"
 do_untar() {
     tar --strip-component=1 -C ${S} -xvf ${S}/cst-${PV}.tgz
 }
-addtask untar after do_unpack before do_populate_lic
+addtask untar after do_unpack before do_patch
 
 EXTRA_OEMAKE = 'CC="${CC}" LD="${CC}" AR="${AR}" OBJCOPY="${OBJCOPY}"'
 


### PR DESCRIPTION
No need to increase the rootfs space with the file utility if we can deduce the filetype looking at the header magic.

Change-type: patch