### PR TITLE
Add delay before authentication panic

### DIFF
--- a/recipes-bsp/u-boot/hab/iot-gate-imx8plus/spl-delay-before-panic-on-authentication-failure.patch
+++ b/recipes-bsp/u-boot/hab/iot-gate-imx8plus/spl-delay-before-panic-on-authentication-failure.patch
@@ -1,0 +1,37 @@
+From df0046e30146268fe184230fb06bf46aa2d6314c Mon Sep 17 00:00:00 2001
+From: Alex Gonzalez <alexg@balena.io>
+Date: Sun, 27 Apr 2025 16:36:21 +0200
+Subject: [PATCH] spl: delay before panic on authentication failure
+
+This gives time for the ethernet interface to come up so that it can be
+monitored as a signal the device has boot up.
+
+This is used in bootloader integrity tests.
+
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+---
+ arch/arm/mach-imx/spl.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm/mach-imx/spl.c b/arch/arm/mach-imx/spl.c
+index 9ca152a943e2..c6438f5ded44 100644
+--- a/arch/arm/mach-imx/spl.c
++++ b/arch/arm/mach-imx/spl.c
+@@ -20,6 +20,7 @@
+ #include <asm/mach-imx/boot_mode.h>
+ #include <g_dnl.h>
+ #include <linux/libfdt.h>
++#include <linux/delay.h>
+ #include <mmc.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+@@ -326,6 +327,9 @@ void board_spl_fit_post_load(const void *fit)
+ 	if (imx_hab_authenticate_image((uintptr_t)fit,
+ 				       offset + IVT_SIZE + CSF_PAD_SIZE,
+ 				       offset)) {
++		/* Give time for ethernet to come up before panic */
++		/* to signal device has booted and use it in tests  */
++		mdelay(3000);
+ 		panic("spl: ERROR:  image authentication unsuccessful\n");
+ 	}
+ }

--- a/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
@@ -30,6 +30,14 @@ do_generate_resin_uboot_configuration[depends] += " \
     virtual/balena-bootloader:do_sign_kernel_bundle \
 "
 
+SRC_URI:append:mx8m-generic-bsp = " \
+    file://security.cfg \
+    file://mach-imx-hab-allow-to-specify-custom-IVT-offset-from.patch \
+    file://image-fdt-introduce-HAB-authentication-for-device-tr.patch \
+    file://cmd-boot-panic-if-image-authentication-fails.patch \
+    file://hab-set-hab-status-in-environment.patch \
+"
+
 SRC_URI:append:iot-gate-imx8 = " \
     file://iot-gate-imx8-extend-the-load-address-for-FDT-files.patch \
     file://iot-gate-imx8-add-placeholder-for-IVT-offset-to-envi.patch \
@@ -40,14 +48,6 @@ SRC_URI:append:iot-gate-imx8plus = " \
     file://compulab-imx8m-plus-adjust-environment-for-secure-bo.patch \
     file://u-boot-compulab-iot-gate-imx8plus-configure-for-secu.patch \
     file://mach-imx-dt_optee-bail-out-if-optee-nodes-exists.patch \
-"
-
-SRC_URI:append:mx8m-generic-bsp = " \
-    file://security.cfg \
-    file://mach-imx-hab-allow-to-specify-custom-IVT-offset-from.patch \
-    file://image-fdt-introduce-HAB-authentication-for-device-tr.patch \
-    file://cmd-boot-panic-if-image-authentication-fails.patch \
-    file://hab-set-hab-status-in-environment.patch \
 "
 
 do_configure:prepend:mx8m-generic-bsp () {

--- a/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
@@ -48,6 +48,7 @@ SRC_URI:append:iot-gate-imx8plus = " \
     file://compulab-imx8m-plus-adjust-environment-for-secure-bo.patch \
     file://u-boot-compulab-iot-gate-imx8plus-configure-for-secu.patch \
     file://mach-imx-dt_optee-bail-out-if-optee-nodes-exists.patch \
+    file://spl-delay-before-panic-on-authentication-failure.patch \
 "
 
 do_configure:prepend:mx8m-generic-bsp () {


### PR DESCRIPTION
This allows for the bootloader integrity tests to detect the device booting via the ethernet port.