### PR TITLE
linux-variscite: imx8mp-var-dart-pl1000pp: restrict to a single devic…

### DIFF
--- a/recipes-kernel/linux/linux-common.inc
+++ b/recipes-kernel/linux/linux-common.inc
@@ -22,3 +22,7 @@ BALENA_CONFIGS[caam] = " \
     CONFIG_CRYPTO_DEV_FSL_CAAM_JR=y \
     CONFIG_CRYPTO_DEV_FSL_CAAM_INTC=y \
 "
+
+KERNEL_DEVICETREE:imx8mp-var-dart-pl1000pp = " \
+    freescale/imx8mp-var-dart-ae-pl1kpp-1.0.dtb \
+"


### PR DESCRIPTION
…e tree

We only support signing device trees that result in matching offsets.

Change-type: patch